### PR TITLE
Add tag and collection endpoints

### DIFF
--- a/server/handlers/collections.go
+++ b/server/handlers/collections.go
@@ -1,52 +1,135 @@
-// In server/handlers/collections.go, modify GetCollection to:
-func GetCollection(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    colIDStr := c.Param("id")
-    colID, err := strconv.Atoi(colIDStr)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid collection id"})
-      return
-    }
-    var col models.Collection
-    row := db.QueryRow(`SELECT id, title, description, created_by FROM collections WHERE id=$1`, colID)
-    if err := row.Scan(&col.ID, &col.Title, &col.Description, &col.CreatedBy); err != nil {
-      if err == sql.ErrNoRows {
-        c.JSON(http.StatusNotFound, gin.H{"error": "collection not found"})
-      } else {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      }
-      return
-    }
-    rows, err := db.Query(
-      `SELECT images.id, images.url, images.caption, images.tags, images.hearts, 
-              images.uploaded_by, images.uploaded_at
-       FROM images
-       JOIN collection_images ON images.id = collection_images.image_id
-       WHERE collection_images.collection_id = $1`,
-      colID,
-    )
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    defer rows.Close()
+package handlers
 
-    var imgs []models.Image
-    for rows.Next() {
-      var img models.Image
-      var tags pq.StringArray
-      if err := rows.Scan(
-        &img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
-      ); err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-        return
-      }
-      img.Tags = tags
-      imgs = append(imgs, img)
-    }
-    c.JSON(http.StatusOK, gin.H{
-      "collection": col,
-      "images":     imgs,
-    })
-  }
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	pq "github.com/lib/pq"
+
+	"github.com/chardebeer/we-spark-canvas/server/models"
+)
+
+// CreateCollection handles POST /collections
+func CreateCollection(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input struct {
+			Title       string `json:"title" binding:"required"`
+			Description string `json:"description"`
+			CreatedBy   int    `json:"created_by" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		var id int
+		err := db.QueryRow(`INSERT INTO collections (title, description, created_by) VALUES ($1,$2,$3) RETURNING id`,
+			input.Title, input.Description, input.CreatedBy).Scan(&id)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"id": id})
+	}
+}
+
+// AddImageToCollection handles POST /collections/:id/images
+func AddImageToCollection(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		colID, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid collection id"})
+			return
+		}
+		var input struct {
+			ImageID int `json:"image_id" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		_, err = db.Exec(`INSERT INTO collection_images (collection_id, image_id) VALUES ($1,$2)`, colID, input.ImageID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusCreated)
+	}
+}
+
+// GetCollections handles GET /collections
+func GetCollections(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rows, err := db.Query(`SELECT id, title, description, created_by FROM collections ORDER BY id DESC`)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+
+		var cols []models.Collection
+		for rows.Next() {
+			var col models.Collection
+			if err := rows.Scan(&col.ID, &col.Title, &col.Description, &col.CreatedBy); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			cols = append(cols, col)
+		}
+		c.JSON(http.StatusOK, cols)
+	}
+}
+
+// GetCollection handles GET /collections/:id and returns collection with its images
+func GetCollection(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		colIDStr := c.Param("id")
+		colID, err := strconv.Atoi(colIDStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid collection id"})
+			return
+		}
+		var col models.Collection
+		row := db.QueryRow(`SELECT id, title, description, created_by FROM collections WHERE id=$1`, colID)
+		if err := row.Scan(&col.ID, &col.Title, &col.Description, &col.CreatedBy); err != nil {
+			if err == sql.ErrNoRows {
+				c.JSON(http.StatusNotFound, gin.H{"error": "collection not found"})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		rows, err := db.Query(
+			`SELECT images.id, images.url, images.caption, images.tags, images.hearts,
+                    images.uploaded_by, images.uploaded_at
+             FROM images
+             JOIN collection_images ON images.id = collection_images.image_id
+             WHERE collection_images.collection_id = $1`,
+			colID,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+
+		var imgs []models.Image
+		for rows.Next() {
+			var img models.Image
+			var tags pq.StringArray
+			if err := rows.Scan(
+				&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
+			); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			img.Tags = tags
+			imgs = append(imgs, img)
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"collection": col,
+			"images":     imgs,
+		})
+	}
 }

--- a/server/handlers/images.go
+++ b/server/handlers/images.go
@@ -1,159 +1,250 @@
 package handlers
 
 import (
-  "database/sql"                // for *sql.DB, sql.ErrNoRows
-  "net/http"
-  "strconv"
-  "strings"
+	"database/sql" // for *sql.DB, sql.ErrNoRows
+	"net/http"
+	"strconv"
+	"strings"
 
-  "github.com/gin-gonic/gin"
-  shell "github.com/ipfs/go-ipfs-api"
-  pq "github.com/lib/pq"         // ← Import pq for pq.Array usage
-  "github.com/chardebeer/we-spark-canvas/server/models"
+	"github.com/gin-gonic/gin"
+	shell "github.com/ipfs/go-ipfs-api"
+	pq "github.com/lib/pq" // ← Import pq for pq.Array usage
+
+	"github.com/chardebeer/we-spark-canvas/server/models"
 )
 
 // UploadImage handles POST /images
 // Expects multipart form: file, caption, tags (comma-separated), uploaded_by
 func UploadImage(db *sql.DB, ipfsShell *shell.Shell) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    // 1. Parse multipart form
-    file, err := c.FormFile("file")
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
-      return
-    }
-    caption := c.PostForm("caption")
-    tagsStr := c.PostForm("tags")
-    uploadedByStr := c.PostForm("uploaded_by")
-    uploadedBy, err := strconv.Atoi(uploadedByStr)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid uploaded_by"})
-      return
-    }
+	return func(c *gin.Context) {
+		// 1. Parse multipart form
+		file, err := c.FormFile("file")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
+			return
+		}
+		caption := c.PostForm("caption")
+		tagsStr := c.PostForm("tags")
+		uploadedByStr := c.PostForm("uploaded_by")
+		uploadedBy, err := strconv.Atoi(uploadedByStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid uploaded_by"})
+			return
+		}
 
-    // 2. Read file into IPFS
-    f, err := file.Open()
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    defer f.Close()
+		// 2. Read file into IPFS
+		f, err := file.Open()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer f.Close()
 
-    cid, err := ipfsShell.Add(f)
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": "IPFS upload failed"})
-      return
-    }
-    // Construct a gateway URL for retrieval
-    url := "https://ipfs.io/ipfs/" + cid
+		cid, err := ipfsShell.Add(f)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "IPFS upload failed"})
+			return
+		}
+		// Construct a gateway URL for retrieval
+		url := "https://ipfs.io/ipfs/" + cid
 
-    // 3. Insert into PostgreSQL
-    tagsArray := []string{}
-    if tagsStr != "" {
-      tagsArray = strings.Split(tagsStr, ",")
-    }
-    var imageID int
-    err = db.QueryRow(
-      `INSERT INTO images (url, caption, tags, hearts, uploaded_by) 
+		// 3. Insert into PostgreSQL
+		tagsArray := []string{}
+		if tagsStr != "" {
+			tagsArray = strings.Split(tagsStr, ",")
+		}
+		var imageID int
+		err = db.QueryRow(
+			`INSERT INTO images (url, caption, tags, hearts, uploaded_by) 
        VALUES ($1, $2, $3, 0, $4) RETURNING id`,
-      url, caption, pq.Array(tagsArray), uploadedBy,
-    ).Scan(&imageID)
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
+			url, caption, pq.Array(tagsArray), uploadedBy,
+		).Scan(&imageID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 
-    c.JSON(http.StatusCreated, gin.H{"id": imageID, "url": url})
-  }
+		c.JSON(http.StatusCreated, gin.H{"id": imageID, "url": url})
+	}
 }
 
 // GetImages handles GET /images?limit=20&offset=0
 func GetImages(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    limitStr := c.DefaultQuery("limit", "20")
-    offsetStr := c.DefaultQuery("offset", "0")
-    limit, err := strconv.Atoi(limitStr)
-    if err != nil {
-      limit = 20
-    }
-    offset, err := strconv.Atoi(offsetStr)
-    if err != nil {
-      offset = 0
-    }
+	return func(c *gin.Context) {
+		limitStr := c.DefaultQuery("limit", "20")
+		offsetStr := c.DefaultQuery("offset", "0")
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			limit = 20
+		}
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			offset = 0
+		}
 
-    rows, err := db.Query(
-      `SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at 
+		rows, err := db.Query(
+			`SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at 
        FROM images ORDER BY uploaded_at DESC LIMIT $1 OFFSET $2`,
-      limit, offset,
-    )
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    defer rows.Close()
+			limit, offset,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
 
-    images := []models.Image{}
-    for rows.Next() {
-      var img models.Image
-      var tags pq.StringArray
-      if err := rows.Scan(
-        &img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
-      ); err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-        return
-      }
-      img.Tags = tags
-      images = append(images, img)
-    }
-    c.JSON(http.StatusOK, images)
-  }
+		images := []models.Image{}
+		for rows.Next() {
+			var img models.Image
+			var tags pq.StringArray
+			if err := rows.Scan(
+				&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
+			); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			img.Tags = tags
+			images = append(images, img)
+		}
+		c.JSON(http.StatusOK, images)
+	}
 }
 
 // HeartImage handles POST /images/:id/heart
 func HeartImage(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    idStr := c.Param("id")
-    id, err := strconv.Atoi(idStr)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid image id"})
-      return
-    }
-    // Increment heart count
-    _, err = db.Exec(`UPDATE images SET hearts = hearts + 1 WHERE id = $1`, id)
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    c.JSON(http.StatusOK, gin.H{"message": "hearted"})
-  }
+	return func(c *gin.Context) {
+		idStr := c.Param("id")
+		imageID, err := strconv.Atoi(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid image id"})
+			return
+		}
+		var input struct {
+			UserID int `json:"user_id" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer tx.Rollback()
+
+		_, err = tx.Exec(`INSERT INTO image_hearts (image_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING`, imageID, input.UserID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		_, err = tx.Exec(`UPDATE images SET hearts = (SELECT COUNT(*) FROM image_hearts WHERE image_id=$1) WHERE id=$1`, imageID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		var count int
+		if err := tx.QueryRow(`SELECT hearts FROM images WHERE id=$1`, imageID).Scan(&count); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if err := tx.Commit(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"hearts": count})
+	}
 }
 
 // GetImage handles GET /images/:id
 func GetImage(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    idStr := c.Param("id")
-    id, err := strconv.Atoi(idStr)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid image id"})
-      return
-    }
-    var img models.Image
-    var tags pq.StringArray
-    row := db.QueryRow(
-      `SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at 
+	return func(c *gin.Context) {
+		idStr := c.Param("id")
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid image id"})
+			return
+		}
+		var img models.Image
+		var tags pq.StringArray
+		row := db.QueryRow(
+			`SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at 
        FROM images WHERE id=$1`, id,
-    )
-    if err := row.Scan(
-      &img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
-    ); err != nil {
-      if err == sql.ErrNoRows {
-        c.JSON(http.StatusNotFound, gin.H{"error": "image not found"})
-      } else {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      }
-      return
-    }
-    img.Tags = tags
-    c.JSON(http.StatusOK, img)
-  }
+		)
+		if err := row.Scan(
+			&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
+		); err != nil {
+			if err == sql.ErrNoRows {
+				c.JSON(http.StatusNotFound, gin.H{"error": "image not found"})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		img.Tags = tags
+		c.JSON(http.StatusOK, img)
+	}
+}
+
+// GetImagesByTag handles GET /images/tag/:tag
+func GetImagesByTag(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tag := c.Param("tag")
+		limitStr := c.DefaultQuery("limit", "20")
+		offsetStr := c.DefaultQuery("offset", "0")
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			limit = 20
+		}
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			offset = 0
+		}
+		rows, err := db.Query(`SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at FROM images WHERE $1 = ANY(tags) ORDER BY uploaded_at DESC LIMIT $2 OFFSET $3`, tag, limit, offset)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+		var images []models.Image
+		for rows.Next() {
+			var img models.Image
+			var tags pq.StringArray
+			if err := rows.Scan(&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			img.Tags = tags
+			images = append(images, img)
+		}
+		c.JSON(http.StatusOK, images)
+	}
+}
+
+// GetTrendingTags handles GET /tags/trending
+func GetTrendingTags(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rows, err := db.Query(`SELECT tag, COUNT(*) as cnt FROM (SELECT unnest(tags) AS tag FROM images WHERE uploaded_at >= NOW() - INTERVAL '24 hours') t GROUP BY tag ORDER BY cnt DESC LIMIT 20`)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+
+		type TagCount struct {
+			Tag   string `json:"tag"`
+			Count int    `json:"count"`
+		}
+		var tags []TagCount
+		for rows.Next() {
+			var tc TagCount
+			if err := rows.Scan(&tc.Tag, &tc.Count); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			tags = append(tags, tc)
+		}
+		c.JSON(http.StatusOK, tags)
+	}
 }

--- a/server/handlers/users.go
+++ b/server/handlers/users.go
@@ -1,95 +1,136 @@
 package handlers
 
 import (
-  "database/sql"
-  "net/http"
-  "strconv"
+	"database/sql"
+	"net/http"
+	"strconv"
 
-  "github.com/gin-gonic/gin"
-  "github.com/chardebeer/we-spark-canvas/server/models"
+	"github.com/gin-gonic/gin"
+	pq "github.com/lib/pq"
+
+	"github.com/chardebeer/we-spark-canvas/server/models"
 )
 
 // CreateUser handles POST /users
 func CreateUser(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    var input struct {
-      Username  string `json:"username" binding:"required"`
-      AvatarURL string `json:"avatar_url"`
-    }
-    if err := c.ShouldBindJSON(&input); err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-      return
-    }
-    var userID int
-    err := db.QueryRow(
-      "INSERT INTO users (username, avatar_url) VALUES ($1, $2) RETURNING id",
-      input.Username, input.AvatarURL,
-    ).Scan(&userID)
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    c.JSON(http.StatusCreated, gin.H{"id": userID})
-  }
+	return func(c *gin.Context) {
+		var input struct {
+			Username  string `json:"username" binding:"required"`
+			AvatarURL string `json:"avatar_url"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		var userID int
+		err := db.QueryRow(
+			"INSERT INTO users (username, avatar_url) VALUES ($1, $2) RETURNING id",
+			input.Username, input.AvatarURL,
+		).Scan(&userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"id": userID})
+	}
 }
 
 // GetUser handles GET /users/:id
 func GetUser(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    idParam := c.Param("id")
-    id, err := strconv.Atoi(idParam)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
-      return
-    }
-    var user models.User
-    row := db.QueryRow("SELECT id, username, avatar_url FROM users WHERE id=$1", id)
-    if err := row.Scan(&user.ID, &user.Username, &user.AvatarURL); err != nil {
-      if err == sql.ErrNoRows {
-        c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-      } else {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      }
-      return
-    }
-    c.JSON(http.StatusOK, user)
-  }
+	return func(c *gin.Context) {
+		idParam := c.Param("id")
+		id, err := strconv.Atoi(idParam)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+		var user models.User
+		row := db.QueryRow("SELECT id, username, avatar_url FROM users WHERE id=$1", id)
+		if err := row.Scan(&user.ID, &user.Username, &user.AvatarURL); err != nil {
+			if err == sql.ErrNoRows {
+				c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, user)
+	}
 }
+
 // GetUserImages handles GET /users/:id/images
 func GetUserImages(db *sql.DB) gin.HandlerFunc {
-  return func(c *gin.Context) {
-    idStr := c.Param("id")
-    userID, err := strconv.Atoi(idStr)
-    if err != nil {
-      c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
-      return
-    }
-    rows, err := db.Query(
-      `SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at
+	return func(c *gin.Context) {
+		idStr := c.Param("id")
+		userID, err := strconv.Atoi(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+		rows, err := db.Query(
+			`SELECT id, url, caption, tags, hearts, uploaded_by, uploaded_at
        FROM images
        WHERE uploaded_by = $1
        ORDER BY uploaded_at DESC`,
-      userID,
-    )
-    if err != nil {
-      c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-      return
-    }
-    defer rows.Close()
+			userID,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
 
-    var images []models.Image
-    for rows.Next() {
-      var img models.Image
-      var tags pq.StringArray
-      if err := rows.Scan(
-        &img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
-      ); err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-        return
-      }
-      img.Tags = tags
-      images = append(images, img)
-    }
-    c.JSON(http.StatusOK, images)
-  }
+		var images []models.Image
+		for rows.Next() {
+			var img models.Image
+			var tags pq.StringArray
+			if err := rows.Scan(
+				&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt,
+			); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			img.Tags = tags
+			images = append(images, img)
+		}
+		c.JSON(http.StatusOK, images)
+	}
+}
+
+// GetUserHearts handles GET /users/:id/hearts
+func GetUserHearts(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		idStr := c.Param("id")
+		userID, err := strconv.Atoi(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+		rows, err := db.Query(
+			`SELECT images.id, images.url, images.caption, images.tags, images.hearts, images.uploaded_by, images.uploaded_at
+             FROM images
+             JOIN image_hearts ON images.id = image_hearts.image_id
+             WHERE image_hearts.user_id = $1
+             ORDER BY images.uploaded_at DESC`,
+			userID,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer rows.Close()
+
+		var images []models.Image
+		for rows.Next() {
+			var img models.Image
+			var tags pq.StringArray
+			if err := rows.Scan(&img.ID, &img.URL, &img.Caption, &tags, &img.Hearts, &img.UploadedBy, &img.UploadedAt); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			img.Tags = tags
+			images = append(images, img)
+		}
+		c.JSON(http.StatusOK, images)
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -1,63 +1,68 @@
 package main
 
 import (
-  "log"
-  "os"
-  "time"
+	"log"
+	"os"
+	"time"
 
-  "github.com/gin-contrib/cors"
-  "github.com/gin-gonic/gin"
-  "github.com/joho/godotenv"
-  shell "github.com/ipfs/go-ipfs-api"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/joho/godotenv"
 
-  "github.com/chardebeer/we-spark-canvas/server/handlers"
-  "github.com/chardebeer/we-spark-canvas/server/storage"
+	"github.com/chardebeer/we-spark-canvas/server/handlers"
+	"github.com/chardebeer/we-spark-canvas/server/storage"
 )
 
 func main() {
-  godotenv.Load(".env")
+	godotenv.Load(".env")
 
-  db := storage.NewPostgresDB()
-  ipfsURL := os.Getenv("IPFS_API_URL")
-  if ipfsURL == "" {
-    ipfsURL = "http://127.0.0.1:5001"
-  }
-  ipfsShell := shell.NewShell(ipfsURL)
+	db := storage.NewPostgresDB()
+	ipfsURL := os.Getenv("IPFS_API_URL")
+	if ipfsURL == "" {
+		ipfsURL = "http://127.0.0.1:5001"
+	}
+	ipfsShell := shell.NewShell(ipfsURL)
 
-  router := gin.Default()
+	router := gin.Default()
 
-  // Enable CORS for your Next.js frontend
-  router.Use(cors.New(cors.Config{
-    AllowOrigins:     []string{"http://localhost:3000"},
-    AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-    AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
-    ExposeHeaders:    []string{"Content-Length"},
-    AllowCredentials: true,
-    MaxAge:           12 * time.Hour,
-  }))
+	// Enable CORS for your Next.js frontend
+	router.Use(cors.New(cors.Config{
+		AllowOrigins:     []string{"http://localhost:3000"},
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
+		ExposeHeaders:    []string{"Content-Length"},
+		AllowCredentials: true,
+		MaxAge:           12 * time.Hour,
+	}))
 
-  // User routes
-  router.POST("/users", handlers.CreateUser(db))
-  router.GET("/users/:id", handlers.GetUser(db))
-router.GET("/users/:id/images", handlers.GetUserImages(db))
+	// User routes
+	router.POST("/users", handlers.CreateUser(db))
+	router.GET("/users/:id", handlers.GetUser(db))
+	router.GET("/users/:id/images", handlers.GetUserImages(db))
+	router.GET("/users/:id/hearts", handlers.GetUserHearts(db))
 
-  // Image routes
-  router.POST("/images", handlers.UploadImage(db, ipfsShell))
-  router.GET("/images", handlers.GetImages(db))
-  router.GET("/images/:id", handlers.GetImage(db))
-  router.POST("/images/:id/heart", handlers.HeartImage(db))
+	// Image routes
+	router.POST("/images", handlers.UploadImage(db, ipfsShell))
+	router.GET("/images", handlers.GetImages(db))
+	router.GET("/images/:id", handlers.GetImage(db))
+	router.GET("/images/tag/:tag", handlers.GetImagesByTag(db))
+	router.POST("/images/:id/heart", handlers.HeartImage(db))
 
-  // Collection routes
-  router.POST("/collections", handlers.CreateCollection(db))
-  router.POST("/collections/:id/images", handlers.AddImageToCollection(db))
-  router.GET("/collections/:id", handlers.GetCollection(db))
+	router.GET("/tags/trending", handlers.GetTrendingTags(db))
 
-  port := os.Getenv("PORT")
-  if port == "" {
-    port = "8080"
-  }
-  log.Printf("🚀 We Spark Canvas REST API running on port %s", port)
-  if err := router.Run(":" + port); err != nil {
-    log.Fatalf("failed to run server: %v", err)
-  }
+	// Collection routes
+	router.POST("/collections", handlers.CreateCollection(db))
+	router.POST("/collections/:id/images", handlers.AddImageToCollection(db))
+	router.GET("/collections", handlers.GetCollections(db))
+	router.GET("/collections/:id", handlers.GetCollection(db))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("🚀 We Spark Canvas REST API running on port %s", port)
+	if err := router.Run(":" + port); err != nil {
+		log.Fatalf("failed to run server: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- implement collection CRUD handlers and register them
- track hearts in join table
- expose filtering by tag and trending tags endpoints
- list user hearts

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843650445cc832d82dc41e9adb37c21